### PR TITLE
feat: Add duplicate email error handling

### DIFF
--- a/src/app/api/attendees/route.ts
+++ b/src/app/api/attendees/route.ts
@@ -66,8 +66,17 @@ export async function POST(request: NextRequest) {
       { message: "Registration successful!", data: newAttendee },
       { status: 201 },
     );
-  } catch (error) {
+  } catch (error: any) {
     console.error("POST Attendee API Error:", error);
+
+    // Handle unique constraint violation for email
+    if (error.code === "P2002" && error.meta?.target?.includes("email")) {
+      return NextResponse.json(
+        { message: "El correo electrónico ya está registrado." },
+        { status: 409 },
+      );
+    }
+
     return NextResponse.json(
       { message: "An internal server error occurred." },
       { status: 500 },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import Step3_ThankYou from "@/components/Step3_ThankYou";
 export default function Home() {
   const [currentStep, setCurrentStep] = useState(1);
   const [message, setMessage] = useState({ text: "", show: false });
+  const [error, setError] = useState({ text: "", show: false });
 
   // Handle message display and timeout
   useEffect(() => {
@@ -21,8 +22,21 @@ export default function Home() {
     }
   }, [message]);
 
+  useEffect(() => {
+    if (error.show) {
+      const timer = setTimeout(() => {
+        setError({ text: "", show: false });
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [error]);
+
   const handleNoClick = () => {
     setMessage({ text: "Qué lástima. ¡Te extrañaremos! 😢", show: true });
+  };
+
+  const handleRegistrationError = (errorMessage: string) => {
+    setError({ text: errorMessage, show: true });
   };
 
   const renderStep = () => {
@@ -35,7 +49,12 @@ export default function Home() {
           />
         );
       case 2:
-        return <Step2_Form onSubmit={() => setCurrentStep(3)} />;
+        return (
+          <Step2_Form
+            onSubmit={() => setCurrentStep(3)}
+            onRegistrationError={handleRegistrationError}
+          />
+        );
       case 3:
         return <Step3_ThankYou />;
       default:
@@ -74,6 +93,15 @@ export default function Home() {
         }`}
       >
         {message.text}
+      </div>
+
+      {/* Error Toast */}
+      <div
+        className={`fixed top-8 left-1/2 -translate-x-1/2 py-3 px-6 rounded-xl bg-red-500 text-white text-base shadow-lg z-50 transition-all duration-300 pointer-events-none ${
+          error.show ? "opacity-100 visible top-28" : "opacity-0 invisible"
+        }`}
+      >
+        {error.text}
       </div>
     </>
   );

--- a/src/components/Step2_Form.tsx
+++ b/src/components/Step2_Form.tsx
@@ -2,7 +2,13 @@
 import { FormEvent, useState } from "react";
 import { motion } from "framer-motion";
 
-export default function Step2_Form({ onSubmit }: { onSubmit: () => void }) {
+export default function Step2_Form({
+  onSubmit,
+  onRegistrationError,
+}: {
+  onSubmit: () => void;
+  onRegistrationError: (message: string) => void;
+}) {
   const [hasAllergy, setHasAllergy] = useState<string | null>(null);
   const [selectedDiets, setSelectedDiets] = useState<string[]>([]);
   const [customDiet, setCustomDiet] = useState<string>("");
@@ -35,7 +41,12 @@ export default function Step2_Form({ onSubmit }: { onSubmit: () => void }) {
       if (response.ok) {
         console.log("Form submitted successfully!");
         onSubmit();
-      } else console.error("Form submission failed.", response);
+      } else if (response.status === 409) {
+        const errorData = await response.json();
+        onRegistrationError(errorData.message);
+      } else {
+        console.error("Form submission failed.", response);
+      }
     } catch (error) {
       console.error("An error occurred:", error);
     } finally {


### PR DESCRIPTION
This commit introduces error handling for when a user tries to register with an email that has already been used. It includes:

- Backend logic to detect and handle Prisma's unique constraint violation for emails, returning a 409 Conflict status.
- A new error toast notification on the frontend to inform the user that the email is already registered.